### PR TITLE
Fix float spacing issue

### DIFF
--- a/jlreq.satyh
+++ b/jlreq.satyh
@@ -472,7 +472,7 @@ end = struct
     let height-of-float-boxes pbinfo =
       if is-no-float-page pbinfo then (0pt,0)
       else
-        (!ref-float-boxes) |> List.fold-left (fun (h,n) (pn, bb) -> (
+        (!ref-float-boxes) |> List.fold-right (fun (pn, bb) (h,n) -> (
           if pn > pbinfo#page-number then (h,n)
           else
             let hh = h +' (get-natural-length bb) +' (float-margin config#font-size) in


### PR DESCRIPTION
Since `ref-float-boxes` contains float boxes in reverse order, `height-of-float-boxes` must check them in reverse order using `List.fold-right`.

Otherwise, the actual output of the float boxes (computed [here](https://github.com/abenori/satysfi-class-jlreq/blob/3ca206c490877dfe202c73922378afaf5d3c650c/jlreq.satyh#L510-L517)) and the result of `height-of-float-boxes` may be inconsistent, resulting in incorrect spacing.